### PR TITLE
[boinc-autodock-vina] Simplify config.

### DIFF
--- a/boinc-autodock-vina/README.md
+++ b/boinc-autodock-vina/README.md
@@ -18,15 +18,11 @@ This file supports next parameters:
 - `size_x` - size in the X dimension (Angstrom). This `double` parameter is ignored when `maps` parameter is specified.
 - `size_y` - size in the Y dimension (Angstrom). This `double` parameter is ignored when `maps` parameter is specified.
 - `size_z` - size in the Z dimension (Angstrom). This `double` parameter is ignored when `maps` parameter is specified.
-- `autobox` - sets maps dimensions based on input ligand(s). This parameter is used when `score_only` or `local_only` parameter is specified. This is an **optional** `boolean` parameter. Default value is `false`.
 - `out` - path to output model file (PDBQT). This file should not have absolute path. This is an **optional** parameter.
-- `dir` - path to output directory when: (1) in batch mode, (2) `ligand` parameter is specified and contains more than 1 file and `score_only` is not specified. This directory should not have absolute path. This is an **optional** `string` parameter.
+- `dir` - path to output directory when: (1) in batch mode, (2) `ligand` parameter is specified and contains more than 1 file. This directory should not have absolute path. This is an **optional** `string` parameter.
 - `write_maps` - output filename (directory + prefix name) for maps. Parameter `force_even_voxels` may be needed to comply with map format. This is an **optional** `string` parameter. E.g. for the folder with maps `.\maps\1iep_receptor.A.map` and `.\maps\1iep_receptor.C.map` should be provided as `maps\1iep_receptor`.
-- `score_only` - search space can be omitted. This is an **optional** `boolean` parameter. Default value is `false`.
-- `local_only` - do local search only. This is an **optional** `boolean` parameter. Default value is `false`.
-- `no_refine` - when `receptor` is provided, do not use explicit receptor atoms (instead of precalculated grids) for: (1) local optimization and scoring after docking, (2) `local_only` jobs, and (3) `score_only` jobs. This is an **optional** `boolean` parameter. Default value is `false`.
+- `no_refine` - when `receptor` is provided, do not use explicit receptor atoms (instead of precalculated grids) for local optimization and scoring after docking. This is an **optional** `boolean` parameter. Default value is `false`.
 - `force_even_voxels` - calculated grid maps will have an even number of voxels (intervals) in each dimension (odd number of grid points). This is an **optional** `boolean` parameter. Default value is `false`.
-- `randomize_only` - randomize input, attempting to avoid clashes. This is an **optional** `boolean` parameter. Default value is `false`.
 - `weight_glue` - macrocycle glue weight. This is an optional `double` parameter. Default value is `50.000000`.
 - `seed` - explicit random seed. This is a **required** `integer` parameter.
 - `exhaustiveness` - exhaustiveness of the global search (roughly proportional to time): 1+. This is an **optional** `integer` parameter. Default value is `8`.

--- a/boinc-autodock-vina/src/boinc-autodock-vina/calculate.cpp
+++ b/boinc-autodock-vina/src/boinc-autodock-vina/calculate.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -60,41 +60,19 @@ bool calculator::calculate(const config& config, const int& ncpus, const std::fu
                 vina.load_maps(config.search_area.maps);
             }
             else {
-                if ((config.advanced.score_only || config.advanced.local_only) && config.search_area.autobox) {
-                    const auto& dim = vina.grid_dimensions_from_ligand();
-                    vina.compute_vina_maps(dim[0], dim[1], dim[2], dim[3], dim[4], dim[5],
-                        config.misc.spacing, config.advanced.force_even_voxels);
-                }
-                else {
-                    vina.compute_vina_maps(config.search_area.center_x, config.search_area.center_y,
-                        config.search_area.center_z, config.search_area.size_x, config.search_area.size_y,
-                        config.search_area.size_z, config.misc.spacing,
-                        config.advanced.force_even_voxels);
-                }
+                vina.compute_vina_maps(config.search_area.center_x, config.search_area.center_y,
+                    config.search_area.center_z, config.search_area.size_x, config.search_area.size_y,
+                    config.search_area.size_z, config.misc.spacing,
+                    config.advanced.force_even_voxels);
 
                 if (!config.output.write_maps.empty())
                     vina.write_maps(config.output.write_maps);
             }
         }
 
-        if (config.advanced.randomize_only) {
-            vina.randomize();
-            vina.write_pose(config.output.out);
-        }
-        else if (config.advanced.score_only) {
-            const auto& energies = vina.score();
-            vina.show_score(energies);
-        }
-        else if (config.advanced.local_only) {
-            const auto& energies = vina.optimize();
-            vina.write_pose(config.output.out);
-            vina.show_score(energies);
-        }
-        else {
-            vina.global_search(config.misc.exhaustiveness, config.misc.num_modes, config.misc.min_rmsd,
-                config.misc.max_evals);
-            vina.write_poses(config.output.out, config.misc.num_modes, config.misc.energy_range);
-        }
+        vina.global_search(config.misc.exhaustiveness, config.misc.num_modes, config.misc.min_rmsd,
+            config.misc.max_evals);
+        vina.write_poses(config.output.out, config.misc.num_modes, config.misc.energy_range);
     }
     else if (!config.input.batch.empty()) {
         if (config.input.scoring == scoring::vina) {
@@ -116,22 +94,9 @@ bool calculator::calculate(const config& config, const int& ncpus, const std::fu
 
             const auto& out_name = (std::filesystem::path(config.output.dir) / b).string();
 
-            if (config.advanced.randomize_only) {
-                vina.randomize();
-                vina.write_pose(out_name);
-            }
-            else if (config.advanced.score_only) {
-                vina.score();
-            }
-            else if (config.advanced.local_only) {
-                vina.optimize();
-                vina.write_pose(out_name);
-            }
-            else {
-                vina.global_search(config.misc.exhaustiveness, config.misc.num_modes, config.misc.min_rmsd,
-                    config.misc.max_evals);
-                vina.write_poses(out_name, config.misc.num_modes, config.misc.energy_range);
-            }
+            vina.global_search(config.misc.exhaustiveness, config.misc.num_modes, config.misc.min_rmsd,
+                config.misc.max_evals);
+            vina.write_poses(out_name, config.misc.num_modes, config.misc.energy_range);
         }
     }
 

--- a/boinc-autodock-vina/src/common/config.cpp
+++ b/boinc-autodock-vina/src/common/config.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -192,9 +192,6 @@ bool search_area::load(const jsoncons::basic_json<char>& json, const std::filesy
     if (json.contains("size_z")) {
         size_z = json["size_z"].as<double>();
     }
-    if (json.contains("autobox")) {
-        autobox = json["autobox"].as<bool>();
-    }
 
     return true;
 }
@@ -243,11 +240,6 @@ bool search_area::save(const json_encoder_helper& json, const std::filesystem::p
 
     if (!json.value("size_z", size_z)) {
         error_message("size_z");
-        return false;
-    }
-
-    if (!json.value("autobox", autobox)) {
-        error_message("autobox");
         return false;
     }
 
@@ -318,20 +310,11 @@ bool output::save(const json_encoder_helper& json, const std::filesystem::path& 
 }
 
 bool advanced::load(const jsoncons::basic_json<char>& json, [[maybe_unused]] const std::filesystem::path& working_directory) {
-    if (json.contains("score_only")) {
-        score_only = json["score_only"].as<bool>();
-    }
-    if (json.contains("local_only")) {
-        local_only = json["local_only"].as<bool>();
-    }
     if (json.contains("no_refine")) {
         no_refine = json["no_refine"].as<bool>();
     }
     if (json.contains("force_even_voxels")) {
         force_even_voxels = json["force_even_voxels"].as<bool>();
-    }
-    if (json.contains("randomize_only")) {
-        randomize_only = json["randomize_only"].as<bool>();
     }
     if (json.contains("weight_gauss1")) {
         weight_gauss1 = json["weight_gauss1"].as<double>();
@@ -394,16 +377,6 @@ bool advanced::save(const json_encoder_helper& json, const std::filesystem::path
         std::cerr << std::endl;
     };
 
-    if (!json.value("score_only", score_only)) {
-        error_message("score_only");
-        return false;
-    }
-
-    if (!json.value("local_only", local_only)) {
-        error_message("local_only");
-        return false;
-    }
-
     if (!json.value("no_refine", no_refine)) {
         error_message("no_refine");
         return false;
@@ -411,11 +384,6 @@ bool advanced::save(const json_encoder_helper& json, const std::filesystem::path
 
     if (!json.value("force_even_voxels", force_even_voxels)) {
         error_message("force_even_voxels");
-        return false;
-    }
-
-    if (!json.value("randomize_only", randomize_only)) {
-        error_message("randomize_only");
         return false;
     }
 
@@ -599,7 +567,7 @@ bool config::validate() const {
             return false;
         }
         if (search_area.maps.empty()) {
-            std::cerr << "maps are missing.";
+            std::cerr << "Maps are missing.";
             std::cerr << std::endl;
             return false;
         }
@@ -628,12 +596,10 @@ bool config::validate() const {
         return false;
     }
 
-    if (!advanced.score_only) {
-        if (!input.ligands.empty() && output.out.empty()) {
-            std::cerr << "Need to specify an output.out parameter";
-            std::cerr << std::endl;
-            return false;
-        }
+    if (output.out.empty()) {
+        std::cerr << "Need to specify an output.out parameter";
+        std::cerr << std::endl;
+        return false;
     }
 
     return check_files_exist();

--- a/boinc-autodock-vina/src/common/config.h
+++ b/boinc-autodock-vina/src/common/config.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -65,7 +65,6 @@ public:
     double size_x = .0;
     double size_y = .0;
     double size_z = .0;
-    bool autobox = false;
 
     [[nodiscard]] bool load(const jsoncons::basic_json<char>& json, const std::filesystem::path& working_directory) override;
     [[nodiscard]] bool save(const json_encoder_helper& json, const std::filesystem::path& working_directory) const override;
@@ -83,11 +82,8 @@ public:
 
 class advanced final : public json_load, public json_save {
 public:
-    bool score_only = false;
-    bool local_only = false;
     bool no_refine = false;
     bool force_even_voxels = false;
-    bool randomize_only = false;
     double weight_gauss1 = -0.035579;
     double weight_gauss2 = -0.005156;
     double weight_repulsion = 0.840245;

--- a/boinc-autodock-vina/src/unit-tests/config-tests.cpp
+++ b/boinc-autodock-vina/src/unit-tests/config-tests.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -361,15 +361,11 @@ TEST_F(Config_UnitTests, LoadValidator) {
     json_encoder.value("size_x", -0.654321);
     json_encoder.value("size_y", 0.0);
     json_encoder.value("size_z", -0.000135);
-    json_encoder.value("autobox", true);
     json_encoder.value("out", "out_sample");
     json_encoder.value("dir", "dir_sample");
     json_encoder.value("write_maps", "write_maps_sample");
-    json_encoder.value("score_only", true);
-    json_encoder.value("local_only", true);
     json_encoder.value("no_refine", true);
     json_encoder.value("force_even_voxels", true);
-    json_encoder.value("randomize_only", true);
     json_encoder.value("weight_gauss1", 0.123456);
     json_encoder.value("weight_gauss2", -0.123456);
     json_encoder.value("weight_repulsion", 0.654321);
@@ -427,18 +423,14 @@ TEST_F(Config_UnitTests, LoadValidator) {
     EXPECT_DOUBLE_EQ(-0.654321, config.search_area.size_x);
     EXPECT_DOUBLE_EQ(0.0, config.search_area.size_y);
     EXPECT_DOUBLE_EQ(-0.000135, config.search_area.size_z);
-    EXPECT_TRUE(config.search_area.autobox);
     const auto out_sample = std::filesystem::current_path() /= "out_sample";
     EXPECT_STREQ(out_sample.string().c_str(), config.output.out.c_str());
     const auto dir_sample = std::filesystem::current_path() /= "dir_sample";
     EXPECT_STREQ(dir_sample.string().c_str(), config.output.dir.c_str());
     const auto write_maps_sample = std::filesystem::current_path() /= "write_maps_sample";
     EXPECT_STREQ(write_maps_sample.string().c_str(), config.output.write_maps.c_str());
-    EXPECT_TRUE(config.advanced.score_only);
-    EXPECT_TRUE(config.advanced.local_only);
     EXPECT_TRUE(config.advanced.no_refine);
     EXPECT_TRUE(config.advanced.force_even_voxels);
-    EXPECT_TRUE(config.advanced.randomize_only);
     EXPECT_DOUBLE_EQ(0.123456, config.advanced.weight_gauss1);
     EXPECT_DOUBLE_EQ(-0.123456, config.advanced.weight_gauss2);
     EXPECT_DOUBLE_EQ(0.654321, config.advanced.weight_repulsion);
@@ -750,15 +742,11 @@ TEST_F(Config_UnitTests, TestConfigsEqualAfterReadWrite) {
     json_encoder.value("size_x", -0.654321);
     json_encoder.value("size_y", 0.0);
     json_encoder.value("size_z", -0.000135);
-    json_encoder.value("autobox", true);
     json_encoder.value("out", "out_sample");
     json_encoder.value("dir", "dir_sample");
     json_encoder.value("write_maps", "write_maps_sample");
-    json_encoder.value("score_only", true);
-    json_encoder.value("local_only", true);
     json_encoder.value("no_refine", true);
     json_encoder.value("force_even_voxels", true);
-    json_encoder.value("randomize_only", true);
     json_encoder.value("weight_gauss1", 0.123456);
     json_encoder.value("weight_gauss2", -0.123456);
     json_encoder.value("weight_repulsion", 0.654321);
@@ -814,15 +802,11 @@ TEST_F(Config_UnitTests, TestConfigsEqualAfterReadWrite) {
     EXPECT_DOUBLE_EQ(config.search_area.size_x, config_copy.search_area.size_x);
     EXPECT_DOUBLE_EQ(config.search_area.size_y, config_copy.search_area.size_y);
     EXPECT_DOUBLE_EQ(config.search_area.size_z, config_copy.search_area.size_z);
-    EXPECT_EQ(config.search_area.autobox, config_copy.search_area.autobox);
     EXPECT_STREQ(config.output.out.c_str(), config_copy.output.out.c_str());
     EXPECT_STREQ(config.output.dir.c_str(), config_copy.output.dir.c_str());
     EXPECT_STREQ(config.output.write_maps.c_str(), config_copy.output.write_maps.c_str());
-    EXPECT_EQ(config.advanced.score_only, config_copy.advanced.score_only);
-    EXPECT_EQ(config.advanced.local_only, config_copy.advanced.local_only);
     EXPECT_EQ(config.advanced.no_refine, config_copy.advanced.no_refine);
     EXPECT_EQ(config.advanced.force_even_voxels, config_copy.advanced.force_even_voxels);
-    EXPECT_EQ(config.advanced.randomize_only, config_copy.advanced.randomize_only);
     EXPECT_DOUBLE_EQ(config.advanced.weight_gauss1, config_copy.advanced.weight_gauss1);
     EXPECT_DOUBLE_EQ(config.advanced.weight_gauss2, config_copy.advanced.weight_gauss2);
     EXPECT_DOUBLE_EQ(config.advanced.weight_repulsion, config_copy.advanced.weight_repulsion);


### PR DESCRIPTION
Remove 'autobox', 'score_only', 'local_only' and 'randomize_only' parameters.